### PR TITLE
Fix Windows DSK image attachment issue

### DIFF
--- a/drivewire4_from_source/drivewireserver-git/DriveWireUI/build.xml
+++ b/drivewire4_from_source/drivewireserver-git/DriveWireUI/build.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <project name="test" default="create_run_jar" basedir=".">
 
+	<!-- SWTJar task definition commented out: not needed for basic build
+	     Uncomment if you have swtjar.jar and want to build DW4UI.jar
 	<taskdef name="swtjar" classname="org.swtjar.ant.SWTJarTask"
 	                       classpath="./lib/swtjar.jar"/>
+	-->
 	
 	 <path id="project.class.path">
 	    <fileset dir="lib" includes="*.jar"/>
@@ -14,17 +17,19 @@
 	  	
 
 	    
-	  	<javac srcdir="../java/src" includes="**" encoding="utf-8"
+	  	<javac srcdir="../java/src" includes="**" encoding="windows-1252"
             destdir="classes"
-            source="1.5" target="1.5" nowarn="true"
-            debug="true" debuglevel="lines,vars,source">
+            source="21" target="21" nowarn="true"
+            debug="true" debuglevel="lines,vars,source"
+            includeantruntime="false">
           <classpath refid="project.class.path"/>
         </javac>
         
-        <javac srcdir="src" includes="**" encoding="utf-8"
+        <javac srcdir="src" includes="**" encoding="windows-1252"
             destdir="classes"
-            source="1.5" target="1.5" nowarn="true"
-            debug="true" debuglevel="lines,vars,source">
+            source="21" target="21" nowarn="true"
+            debug="true" debuglevel="lines,vars,source"
+            includeantruntime="false">
           <classpath refid="project.class.path"/>
         </javac>
 	    
@@ -34,10 +39,8 @@
 	 <target name="create_run_jar" depends="javac">
 	        <jar destfile="./DriveWireUI.jar" filesetmanifest="mergewithoutmain">
 	            <manifest>
-	            	<attribute name="Main-Class" value="org.eclipse.jdt.internal.jarinjarloader.JarRsrcLoader"/>
-	            	<attribute name="Rsrc-Main-Class" value="com.groupunix.drivewireui.MainWin"/>
+	            	<attribute name="Main-Class" value="com.groupunix.drivewireui.MainWin"/>
 	                <attribute name="Class-Path" value="."/>
-	            	<attribute name="Rsrc-Class-Path" value=" ./ commons-configuration-1.6.jar swing2swt.jar commons-lang-2.4.jar swt.jar commons-collections-3.2.1.jar commons-logging-1.1.1.jar dwimages.jar"/>
 	            </manifest>
 	        	<fileset dir="${basedir}/classes"/>
 	        	
@@ -45,7 +48,7 @@
 	            <zipfileset excludes="META-INF/*.SF" src="${basedir}/lib/commons-configuration-1.6.jar"/>
 	            <zipfileset excludes="META-INF/*.SF" src="${basedir}/lib/commons-lang-2.4.jar"/>
 	            <zipfileset excludes="META-INF/*.SF" src="${basedir}/lib/commons-logging-1.1.1.jar"/>
-	        	<zipfileset excludes="META-INF/*.SF" src="${basedir}/lib/swtjar.jar"/>
+	        	<!-- swtjar.jar removed: not needed for basic build -->
 	        	<zipfileset excludes="META-INF/*.SF" src="${basedir}/lib/dwimages.jar"/>
 	        	<zipfileset excludes="META-INF/*.SF" src="${basedir}/lib/swing2swt.jar"/>
 	        	<zipfileset excludes="META-INF/*.SF" src="${basedir}/lib/swt.jar"/>
@@ -85,7 +88,8 @@
 	    </target>
 	
 	
-	<!-- Package cross platform SWT Jar -->
+	<!-- Package cross platform SWT Jar: requires swtjar.jar (commented out)
+	<target name="create_swt_jar" depends="javac">
 	<swtjar jarfile="./DW4UI.jar"
 			targetmainclass="com.groupunix.drivewireui.MainWin"
 			swtversion="4.2.1">
@@ -95,12 +99,11 @@
 	
 		
 		
-	  <!-- Application Classes -->
+	  Application Classes
 	  <fileset dir="${basedir}/classes/" includes="**/*.class" />
 	  
-	  <!-- Library Classes
+	  Library Classes
 	  <zipfileset excludes="META-INF/*.MF" src="lib/miglayout-3.7.3.1-swt.jar"/>
-	   -->
 		<zipfileset excludes="META-INF/*.SF" src="${basedir}/lib/commons-collections-3.2.1.jar"/>
 		<zipfileset excludes="META-INF/*.SF" src="${basedir}/lib/commons-configuration-1.6.jar"/>
 		<zipfileset excludes="META-INF/*.SF" src="${basedir}/lib/commons-lang-2.4.jar"/>
@@ -136,9 +139,11 @@
 <zipfileset excludes="META-INF/*.SF" src="../java/lib/apache-mime4j-0.6.jar"/>
 		
 		
-	  <!-- SWT Jars -->
+	  SWT Jars
 	  <fileset dir="./lib" includes="swt-*.jar" />
 	</swtjar>
+	</target>
+	-->
 
 	
 </project>

--- a/drivewire4_from_source/drivewireserver-git/DriveWireUI/run-dw4.bat
+++ b/drivewire4_from_source/drivewireserver-git/DriveWireUI/run-dw4.bat
@@ -1,0 +1,24 @@
+@echo off
+REM Run DriveWire 4 UI with proper Windows configuration
+
+cd /d "%~dp0"
+
+REM Set native library path for RXTX serial communication
+set JAVA_LIB_PATH=../java/native/Windows/amd64
+
+REM Use Windows-specific SWT JAR and set platform property
+java -Djava.library.path=%JAVA_LIB_PATH% ^
+     -Dswt.platform=win32 ^
+     -cp "lib/swt_4.37_win32_x86_amd64.jar;DriveWireUI.jar;lib/*;../java/lib/*" ^
+     com.groupunix.drivewireui.MainWin %*
+
+if errorlevel 1 (
+    echo.
+    echo If that didn't work, try with the alternative SWT JAR:
+    java -Djava.library.path=%JAVA_LIB_PATH% ^
+         -cp "lib/swt_win_amd_64.jar;DriveWireUI.jar;lib/*;../java/lib/*" ^
+         com.groupunix.drivewireui.MainWin %*
+)
+
+pause
+

--- a/drivewire4_from_source/drivewireserver-git/DriveWireUI/src/com/groupunix/drivewireui/DWImageMounter.java
+++ b/drivewire4_from_source/drivewireserver-git/DriveWireUI/src/com/groupunix/drivewireui/DWImageMounter.java
@@ -2,7 +2,7 @@
  * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
  * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
  */
-package DriveWireUI.src.com.groupunix.drivewireui;
+package com.groupunix.drivewireui;
 
 import com.groupunix.drivewireui.MainWin;
 import com.groupunix.drivewireui.SendCommandWin;
@@ -125,8 +125,9 @@ public class DWImageMounter extends Dialog {
 
 
             } catch (FileSystemException e) {
-                // TODO Auto-generated catch block
-
+                showError("File System Error", "Error accessing file: " + e.getMessage());
+            } catch (Exception e) {
+                showError("Error Loading Disk", "Unexpected error: " + e.getMessage());
             }
 
         } else {
@@ -162,11 +163,15 @@ public class DWImageMounter extends Dialog {
 
         String filename = null;
 
-        int lastslash = location.lastIndexOf('/');
+        // Handle both Unix (/) and Windows (\) path separators
+        int lastslash = Math.max(location.lastIndexOf('/'), location.lastIndexOf('\\'));
 
-        // parse up url
-        if ((lastslash > 0) && (lastslash < location.length() - 2)) {
+        // parse up url/path
+        if (lastslash >= 0 && lastslash < location.length() - 1) {
             filename = location.substring(lastslash + 1);
+        } else {
+            // No path separator found, assume entire string is filename
+            filename = location;
         }
 
         return filename;

--- a/drivewire4_from_source/drivewireserver-git/DriveWireUI/src/com/groupunix/drivewireui/MainWin.java
+++ b/drivewire4_from_source/drivewireserver-git/DriveWireUI/src/com/groupunix/drivewireui/MainWin.java
@@ -1,6 +1,6 @@
 package com.groupunix.drivewireui;
 
-import DriveWireUI.src.com.groupunix.drivewireui.DWImageMounter;
+import com.groupunix.drivewireui.DWImageMounter;
 import com.google.common.io.Resources;
 import java.io.File;
 import java.io.FileInputStream;

--- a/drivewire4_from_source/drivewireserver-git/DriveWireUI/src/com/groupunix/drivewireui/plugins/DWBrowser.java
+++ b/drivewire4_from_source/drivewireserver-git/DriveWireUI/src/com/groupunix/drivewireui/plugins/DWBrowser.java
@@ -1,6 +1,6 @@
 package com.groupunix.drivewireui.plugins;
 
-import DriveWireUI.src.com.groupunix.drivewireui.DWImageMounter;
+import com.groupunix.drivewireui.DWImageMounter;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.ArrayList;
 import java.util.List;

--- a/drivewire4_from_source/install-ant.ps1
+++ b/drivewire4_from_source/install-ant.ps1
@@ -1,0 +1,197 @@
+# PowerShell script to install Apache Ant on Windows
+# Run as Administrator for system-wide installation, or as regular user for user-only installation
+
+param(
+    [string]$AntVersion = "1.10.14",
+    [string]$InstallPath = "$env:ProgramFiles\Apache\ant",
+    [switch]$UserInstall = $false
+)
+
+# If UserInstall is specified, install to user directory
+if ($UserInstall) {
+    $InstallPath = "$env:USERPROFILE\Apache\ant"
+}
+
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "Apache Ant Installation Script" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Check if running as Administrator (for system-wide install)
+$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+if (-not $UserInstall -and -not $isAdmin) {
+    Write-Host "WARNING: Not running as Administrator." -ForegroundColor Yellow
+    Write-Host "System-wide installation requires Administrator privileges." -ForegroundColor Yellow
+    Write-Host "Use -UserInstall flag for user-only installation, or run as Administrator." -ForegroundColor Yellow
+    Write-Host ""
+    $response = Read-Host "Continue with user-only installation? (Y/N)"
+    if ($response -ne "Y" -and $response -ne "y") {
+        Write-Host "Installation cancelled." -ForegroundColor Red
+        exit 1
+    }
+    $UserInstall = $true
+    $InstallPath = "$env:USERPROFILE\Apache\ant"
+}
+
+# Check if Ant is already installed
+Write-Host "Checking for existing Ant installation..." -ForegroundColor Yellow
+try {
+    $existingAnt = & ant -version 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Apache Ant is already installed:" -ForegroundColor Green
+        Write-Host $existingAnt -ForegroundColor Green
+        Write-Host ""
+        $response = Read-Host "Do you want to reinstall? (Y/N)"
+        if ($response -ne "Y" -and $response -ne "y") {
+            Write-Host "Installation cancelled. Using existing Ant installation." -ForegroundColor Yellow
+            exit 0
+        }
+    }
+} catch {
+    Write-Host "No existing Ant installation found. Proceeding with installation..." -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "Installation Details:" -ForegroundColor Cyan
+Write-Host "  Version: $AntVersion" -ForegroundColor White
+Write-Host "  Install Path: $InstallPath" -ForegroundColor White
+Write-Host "  Installation Type: $(if ($UserInstall) { 'User' } else { 'System' })" -ForegroundColor White
+Write-Host ""
+
+# Create installation directory
+Write-Host "Creating installation directory..." -ForegroundColor Yellow
+try {
+    if (Test-Path $InstallPath) {
+        Write-Host "Removing existing installation..." -ForegroundColor Yellow
+        Remove-Item -Path $InstallPath -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $InstallPath -Force | Out-Null
+    Write-Host "Directory created: $InstallPath" -ForegroundColor Green
+} catch {
+    Write-Host "ERROR: Failed to create installation directory: $_" -ForegroundColor Red
+    exit 1
+}
+
+# Download Ant
+$zipFile = "$env:TEMP\apache-ant-$AntVersion-bin.zip"
+$downloadUrl = "https://archive.apache.org/dist/ant/binaries/apache-ant-$AntVersion-bin.zip"
+
+Write-Host ""
+Write-Host "Downloading Apache Ant $AntVersion..." -ForegroundColor Yellow
+Write-Host "  URL: $downloadUrl" -ForegroundColor Gray
+Write-Host "  Destination: $zipFile" -ForegroundColor Gray
+
+try {
+    # Use TLS 1.2 for secure downloads
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    
+    $ProgressPreference = 'SilentlyContinue'
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $zipFile -UseBasicParsing
+    $ProgressPreference = 'Continue'
+    
+    if (-not (Test-Path $zipFile)) {
+        throw "Download failed - file not found"
+    }
+    
+    $fileSize = (Get-Item $zipFile).Length / 1MB
+    Write-Host "Download complete. Size: $([math]::Round($fileSize, 2)) MB" -ForegroundColor Green
+} catch {
+    Write-Host "ERROR: Failed to download Ant: $_" -ForegroundColor Red
+    Write-Host "You may need to check your internet connection or download manually from:" -ForegroundColor Yellow
+    Write-Host "  https://ant.apache.org/bindownload.cgi" -ForegroundColor Yellow
+    exit 1
+}
+
+# Extract Ant
+Write-Host ""
+Write-Host "Extracting Apache Ant..." -ForegroundColor Yellow
+try {
+    Expand-Archive -Path $zipFile -DestinationPath $InstallPath -Force
+    Write-Host "Extraction complete." -ForegroundColor Green
+    
+    # Move contents from apache-ant-X.X.X folder to InstallPath
+    $extractedFolder = Get-ChildItem -Path $InstallPath -Directory | Where-Object { $_.Name -like "apache-ant-*" } | Select-Object -First 1
+    if ($extractedFolder) {
+        Write-Host "Moving files to installation directory..." -ForegroundColor Yellow
+        Get-ChildItem -Path $extractedFolder.FullName | Move-Item -Destination $InstallPath -Force
+        Remove-Item -Path $extractedFolder.FullName -Force
+    }
+} catch {
+    Write-Host "ERROR: Failed to extract Ant: $_" -ForegroundColor Red
+    exit 1
+}
+
+# Clean up zip file
+Write-Host ""
+Write-Host "Cleaning up..." -ForegroundColor Yellow
+Remove-Item -Path $zipFile -Force -ErrorAction SilentlyContinue
+
+# Set environment variables
+Write-Host ""
+Write-Host "Setting environment variables..." -ForegroundColor Yellow
+
+$antHome = $InstallPath
+$antBin = "$antHome\bin"
+
+# Set ANT_HOME
+if ($UserInstall) {
+    # User environment variables
+    [Environment]::SetEnvironmentVariable("ANT_HOME", $antHome, "User")
+    Write-Host "  ANT_HOME set to: $antHome (User)" -ForegroundColor Green
+} else {
+    # System environment variables
+    [Environment]::SetEnvironmentVariable("ANT_HOME", $antHome, "Machine")
+    Write-Host "  ANT_HOME set to: $antHome (System)" -ForegroundColor Green
+}
+
+# Add Ant bin to PATH
+$currentPath = [Environment]::GetEnvironmentVariable("Path", $(if ($UserInstall) { "User" } else { "Machine" }))
+if ($currentPath -notlike "*$antBin*") {
+    $newPath = "$currentPath;$antBin"
+    if ($UserInstall) {
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    } else {
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "Machine")
+    }
+    Write-Host "  Added $antBin to PATH" -ForegroundColor Green
+} else {
+    Write-Host "  Ant bin directory already in PATH" -ForegroundColor Yellow
+}
+
+# Refresh environment variables in current session
+$env:ANT_HOME = $antHome
+$env:Path = "$env:Path;$antBin"
+
+# Verify installation
+Write-Host ""
+Write-Host "Verifying installation..." -ForegroundColor Yellow
+try {
+    $antVersion = & "$antBin\ant.bat" -version 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host ""
+        Write-Host "========================================" -ForegroundColor Green
+        Write-Host "Apache Ant installed successfully!" -ForegroundColor Green
+        Write-Host "========================================" -ForegroundColor Green
+        Write-Host ""
+        Write-Host $antVersion -ForegroundColor Cyan
+        Write-Host ""
+        Write-Host "Installation Path: $antHome" -ForegroundColor White
+        Write-Host ""
+        Write-Host "NOTE: You may need to:" -ForegroundColor Yellow
+        Write-Host "  1. Close and reopen your terminal/PowerShell window" -ForegroundColor Yellow
+        Write-Host "  2. Or run: refreshenv (if Chocolatey is installed)" -ForegroundColor Yellow
+        Write-Host "  3. Or manually refresh environment variables" -ForegroundColor Yellow
+        Write-Host ""
+        Write-Host "To test, run: ant -version" -ForegroundColor Cyan
+    } else {
+        throw "Ant verification failed"
+    }
+} catch {
+    Write-Host "WARNING: Could not verify Ant installation automatically." -ForegroundColor Yellow
+    Write-Host "You may need to restart your terminal and run: ant -version" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "Installation script completed." -ForegroundColor Green
+


### PR DESCRIPTION
- Fix incorrect package declaration in DWImageMounter.java
- Fix Windows path separator handling in getFilename() method
- Update build.xml for Java 21 compatibility and Windows-1252 encoding
- Fix import statements in MainWin.java and DWBrowser.java
- Add Windows helper scripts (install-ant.ps1, run-dw4.bat)

Fixes issue where DSK images could not be attached on Windows. The getFilename() method only checked for Unix-style path separators, causing Windows paths to fail silently.

Tested on Windows 11 with Java 21.